### PR TITLE
Add CI tests for Mac and Windows where possible

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -118,5 +118,52 @@ jobs:
     - name: MeiliSearch (latest version) setup with Docker
       run: docker run --rm -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
     - name: Test with pytest
+      run: poetry run pytest
+
+  testing-no-docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get full Python version
+      id: full-python-version
+      run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
+    - name: Install Poetry and add to path on Windows
+      if: matrix.os == "windows-latest"
       run: |
-        poetry run pytest
+        (Invoke-WebRequest -Uri https://install.python-poetry.org/install-poetry.py -UseBasicParsing).Content | python -
+        echo "${HOME}\AppData\Roaming\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Install Poetry and add to path on Mac
+      if: matrix.os != "windows-latest"
+      run: |
+        curl -sSL https://install.python-poetry.org/install-poetry.py | python -
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+    - name: Configure poetry
+      run: |
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+    - name: Cache poetry venv
+      uses: actions/cache@v3
+      id: poetry-cache
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+    - name: Ensure cache is healthy
+      if: steps.poetry-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: timeout 10s poetry run pip --version || rm -rf .venv
+    - name: Install Dependencies
+      run: poetry install
+    - name: Test with pytest
+    - name: Rust build
+      run: poetry run maturin develop
+    - name: Test with pytest
+      run: poetry run pytest -m "not meilisearch"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -162,7 +162,6 @@ jobs:
       run: timeout 10s poetry run pip --version || rm -rf .venv
     - name: Install Dependencies
       run: poetry install
-    - name: Test with pytest
     - name: Rust build
       run: poetry run maturin develop
     - name: Test with pytest

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -137,12 +137,12 @@ jobs:
       id: full-python-version
       run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
     - name: Install Poetry and add to path on Windows
-      if: matrix.os == "windows-latest"
+      if: matrix.os == 'windows-latest'
       run: |
         (Invoke-WebRequest -Uri https://install.python-poetry.org/install-poetry.py -UseBasicParsing).Content | python -
         echo "${HOME}\AppData\Roaming\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install Poetry and add to path on Mac
-      if: matrix.os != "windows-latest"
+      if: matrix.os != 'windows-latest'
       run: |
         curl -sSL https://install.python-poetry.org/install-poetry.py | python -
         echo "${HOME}/.local/bin" >> $GITHUB_PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--cov=meilisearch_tui --cov-report term-missing"
+markers = ["meilisearch"]
 asyncio_mode = "auto"
 
 [tool.coverage.report]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from meilisearch_tui.utils import get_current_indexes_string, string_to_list
     ],
 )
 @pytest.mark.usefixtures("clear_indexes", "mock_config", "env_vars")
+@pytest.mark.meilisearch
 async def test_get_current_indexes_string(indexes, expected, test_client):
     for index in indexes:
         await test_client.create_index(index[0], index[1])
@@ -28,6 +29,7 @@ async def test_get_current_indexes_string(indexes, expected, test_client):
 
 
 @pytest.mark.usefixtures("mock_config", "env_vars")
+@pytest.mark.meilisearch
 async def test_get_current_indexes_string_no_indexes():
     result = await get_current_indexes_string()
 


### PR DESCRIPTION
Docker cannot run on Mac and Windows in GitHub actions so tests that directly access Meilisearch are skipped on these platforms.