### PR TITLE
updated search.py with vector search parameters as optional

### DIFF
--- a/meilisearch_tui/screens/search.py
+++ b/meilisearch_tui/screens/search.py
@@ -141,6 +141,7 @@ class SearchScreen(Screen):
                 results = await index.search(
                     self.search_input.value,
                     limit=self.limit,
+                    opt_params={"hybrid": {"semanticRatio": 1.0, "embedder": "default"}},
                     attributes_to_highlight=["*"],
                     highlight_pre_tag="***",
                     highlight_post_tag="***",


### PR DESCRIPTION
found an experimental vector search function in meilisearch python sdk. added this opt_params statement to search.py